### PR TITLE
Fix relative README link

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -22,4 +22,4 @@ mvn exec:java -Dexec.mainClass="com.dnb.openbanking.gettingstarted.GettingStarte
 ```
 
 
-[the main readme]: (../README.md)
+[the main readme]: ../README.md

--- a/python/README.md
+++ b/python/README.md
@@ -32,4 +32,4 @@ in [the main readme][]. The main part is in getting_started.py, which handles th
 process of getting an api token and and calling our APIs as described in the
 [the main readme][].
 
-[the main readme]: (../README.md)
+[the main readme]: ../README.md


### PR DESCRIPTION
Now they are `https://github.com/DNBbank/getting-started/blob/master/python/(../README.md)`
Should be `https://github.com/DNBbank/getting-started/blob/master/README.md`
